### PR TITLE
Major update:

### DIFF
--- a/RW_Automated_Tests/Helpers/DriverFactory.cs
+++ b/RW_Automated_Tests/Helpers/DriverFactory.cs
@@ -12,7 +12,6 @@ namespace RW_Automated_Tests.Helpers
         {
             IWebDriver driver;
             var browser = ConfigurationManager.AppSettings["Browser"];
-            //var browser = "chrome";
 
             switch (browser)
             {

--- a/RW_Automated_Tests/PageObjects/GooglePage.cs
+++ b/RW_Automated_Tests/PageObjects/GooglePage.cs
@@ -33,12 +33,12 @@ namespace RW_Automated_Tests.PageObjects
 
         public void Search(string query)
         {
-            PageMethods.Search(query, SearchInput, SubmitBtn);
+            PageMethods.Search(Driver, query, SearchInput, SubmitBtn);
         }
 
-        public void ClickLink(string partialLink)
+        public void ClickFirstLink()
         {
-            PageMethods.ClickLink(By.XPath("//a[contains(@href, '" + partialLink + "')]"), ResultsPanel);
+            PageMethods.ClickLink(By.XPath("(//h3)[1]/../../a"), ResultsPanel);
         }
 
         public bool PageIsLoaded(string url)

--- a/RW_Automated_Tests/PageObjects/RailwayCalendarPage.cs
+++ b/RW_Automated_Tests/PageObjects/RailwayCalendarPage.cs
@@ -30,7 +30,7 @@ namespace RW_Automated_Tests.PageObjects
         [FindsBy(How = How.XPath, Using = "//input[@id='yDate']")]
         private IWebElement CalendarInput { get; set; }
 
-        [FindsBy(How = How.XPath, Using = "//span[@class='std-button']//input[@type='submit']")]
+        [FindsBy(How = How.XPath, Using = "//span[@class='std-button']/input")]
         private IWebElement ScheduleSearchBtn { get; set; }
 
         [FindsBy(How = How.XPath, Using = "//div[@class='ui-datepicker-group ui-datepicker-group-first']")]
@@ -39,11 +39,22 @@ namespace RW_Automated_Tests.PageObjects
         [FindsBy(How = How.XPath, Using = "//div[@class='ui-datepicker-group ui-datepicker-group-middle']")]
         private IWebElement NextMonth { get; set; }
 
-        [FindsBy(How = How.XPath, Using = "//div[@class='sch-table__row']")]
-        private IWebElement TrainsSchedule { get; set; }
+        [FindsBy(How = How.XPath, Using = "//div[@class='sch-title__title h2']")]
+        private IWebElement TrainNameDiv { get; set; }
+
+        [FindsBy(How = How.XPath, Using = "//span[@class='sch-title__train-num']")]
+        private IWebElement TrainNumberDiv { get; set; }
+
+        [FindsBy(How = How.XPath, Using = "//div[@class='sch-title__descr']")]
+        private IWebElement TravelingDaysInfoLocation { get; set; }
 
         [FindsBy(How = How.XPath, Using = "//img[@title='БелЖД']")]
         private IWebElement LogoImage { get; set; }
+
+        [FindsBy(How = How.XPath, Using = "//a[@class='sch-table__route']")]
+        private IWebElement FirstLinkLocation { get; set; }
+
+
 
         protected internal void Navigate(string url)
         {
@@ -56,7 +67,7 @@ namespace RW_Automated_Tests.PageObjects
             var futureDate = today.AddDays(daysFromToday);
             var targetDay = futureDate.Day;
             var targetMonth = futureDate.Month == today.Month ? CurrentMonth : NextMonth;
-            PageMethods.SearchTrains(FromInput, DestinationInput, CalendarInput, targetMonth, targetDay,
+            PageMethods.SearchTrains(Driver,FromInput, DestinationInput, CalendarInput, targetMonth, targetDay,
                 ScheduleSearchBtn, fromLocation, destination);
         }
 
@@ -65,14 +76,22 @@ namespace RW_Automated_Tests.PageObjects
             return PageMethods.GetTrainsSchedule(Driver);
         }
 
-        protected internal bool ContainsTrainNames()
+        protected internal bool FirstLinkInTrainSearchContainsInformation()
         {
-            return PageMethods.ContainsTrainNames(Driver);
+            FirstLinkLocation.Click();
+            bool containsTrainNames = PageMethods.ContainsTextualInformation(TrainNameDiv);
+            bool containsTrainNumbers = PageMethods.ContainsTextualInformation(TrainNumberDiv);
+            bool containsTravelingDays = PageMethods.ContainsTextualInformation(TravelingDaysInfoLocation); 
+
+            return containsTrainNames && containsTrainNumbers;
         }
 
-        protected internal void ClickLogo()
+        protected internal bool ClickLogoReturnsToHomepage()
         {
-            PageMethods.ClickLogoImage(LogoImage);
+            string homeUrl = "https://www.rw.by/";
+            PageMethods.ClickElement(Driver, LogoImage);
+            bool logoImageReturnsToHomepage = PageMethods.IsUrlCorrect(homeUrl, Driver);
+            return logoImageReturnsToHomepage;
         }
     }
 }

--- a/RW_Automated_Tests/PageObjects/RailwaySearchResultsPage.cs
+++ b/RW_Automated_Tests/PageObjects/RailwaySearchResultsPage.cs
@@ -40,7 +40,7 @@ namespace RW_Automated_Tests.PageObjects
 
         protected internal void Search(string query)
         {
-            PageMethods.Search(query, SearchInput, SiteSearchSubmitBtn);
+            PageMethods.Search(Driver, query, SearchInput, SiteSearchSubmitBtn);
         }
 
         protected internal bool IsUrlCorrect(string requiredUrl)
@@ -55,7 +55,7 @@ namespace RW_Automated_Tests.PageObjects
 
         protected internal void RepeatSearch(string query)
         {
-            PageMethods.Search(query, MiddleSearchInput, SiteSearchSubmitBtn);
+            PageMethods.Search(Driver, query, MiddleSearchInput, SiteSearchSubmitBtn);
         }
 
         protected internal int CountSearchResults()


### PR DESCRIPTION
- tests in UnitTests have been split into smaller and more logically grounded tests
- PageMethods.ElementIsVisible now properly uses WebdriverWait to wait for a specific element to become visible
And some more minor changes to the readability of the code and compliance with DRY paradigm